### PR TITLE
Adapt the test cases to use GFX's multi-viewport feature.

### DIFF
--- a/native/renderer/CMakeLists.txt
+++ b/native/renderer/CMakeLists.txt
@@ -4,9 +4,9 @@ add_subdirectory(gfx-agent)
 add_subdirectory(gfx-validator)
 add_subdirectory(frame-graph)
 
-# add_subdirectory(gfx-gles-common)
-# add_subdirectory(gfx-gles2)
-# add_subdirectory(gfx-gles3)
+add_subdirectory(gfx-gles-common)
+add_subdirectory(gfx-gles2)
+add_subdirectory(gfx-gles3)
 add_subdirectory(gfx-vulkan)
 
 if(APPLE)

--- a/native/renderer/CMakeLists.txt
+++ b/native/renderer/CMakeLists.txt
@@ -4,9 +4,9 @@ add_subdirectory(gfx-agent)
 add_subdirectory(gfx-validator)
 add_subdirectory(frame-graph)
 
-add_subdirectory(gfx-gles-common)
-add_subdirectory(gfx-gles2)
-add_subdirectory(gfx-gles3)
+# add_subdirectory(gfx-gles-common)
+# add_subdirectory(gfx-gles2)
+# add_subdirectory(gfx-gles3)
 add_subdirectory(gfx-vulkan)
 
 if(APPLE)

--- a/src/win/CMakeLists.txt
+++ b/src/win/CMakeLists.txt
@@ -37,9 +37,9 @@ list(APPEND CC_EXTERNAL_LIBS
 
 target_link_libraries(${TARGET_NAME}
   ${ENGINE_BASE_LIBS}
-  GFXGLESCommon
-  GFXGLES2
-  GFXGLES3
+  # GFXGLESCommon
+  # GFXGLES2
+  # GFXGLES3
   GFXVulkan
   ${CC_EXTERNAL_LIBS}
 )

--- a/src/win/CMakeLists.txt
+++ b/src/win/CMakeLists.txt
@@ -37,9 +37,9 @@ list(APPEND CC_EXTERNAL_LIBS
 
 target_link_libraries(${TARGET_NAME}
   ${ENGINE_BASE_LIBS}
-  # GFXGLESCommon
-  # GFXGLES2
-  # GFXGLES3
+  GFXGLESCommon
+  GFXGLES2
+  GFXGLES3
   GFXVulkan
   ${CC_EXTERNAL_LIBS}
 )

--- a/tests/BasicTextureTest.h
+++ b/tests/BasicTextureTest.h
@@ -13,6 +13,11 @@ public:
     bool onInit() override;
     void onDestroy() override;
 
+    struct Vertex {
+        float pos[2];
+        float col[3];
+    };
+
 private:
     void createShader();
     void createVertexBuffer();

--- a/tests/FrameGraphTest.cc
+++ b/tests/FrameGraphTest.cc
@@ -298,7 +298,7 @@ void FrameGraphTest::onTick() {
             builder.writeToBlackboard(depthStencilTexName, data.depthStencilTex);
 
             int           xOff = second * static_cast<int>(swapchain->getWidth()) / 2;
-            gfx::Viewport vp   = {xOff, 0, swapchain->getWidth() / 2, swapchain->getHeight(), 0, 1};
+            gfx::Rect vp   = {xOff, 0, swapchain->getWidth() / 2, swapchain->getHeight()};
             gfx::Rect     rect = {xOff, 0, swapchain->getWidth() / 2, swapchain->getHeight()};
             builder.setViewport(vp, rect);
         };

--- a/tests/MultiViewportTest.cc
+++ b/tests/MultiViewportTest.cc
@@ -1,0 +1,325 @@
+#include <vector>
+
+#include "MultiViewportTest.h"
+#include "gfx-base/GFXDef-common.h"
+#include "tiny_obj_loader.h"
+
+namespace cc {
+
+void MultiViewportTest::onDestroy() {
+    CC_SAFE_DESTROY(_vertexBuffer);
+    CC_SAFE_DESTROY(_inputAssembler);
+    CC_SAFE_DESTROY(_uniformBuffer);
+    CC_SAFE_DESTROY(_uniformBuffer);
+    CC_SAFE_DESTROY(_shader);
+    CC_SAFE_DESTROY(_descriptorSet);
+    CC_SAFE_DESTROY(_descriptorSetLayout);
+    CC_SAFE_DESTROY(_pipelineLayout);
+    CC_SAFE_DESTROY(_pipelineState);
+    CC_SAFE_DESTROY(_invisiblePipelineState);
+    CC_SAFE_DESTROY(_indexBuffer);
+    CC_SAFE_DESTROY(_indirectBuffer);
+}
+
+bool MultiViewportTest::onInit() {
+    createShader();
+    createVertexBuffer();
+    createInputAssembler();
+    createPipeline();
+
+    return true;
+}
+
+void MultiViewportTest::createShader() {
+    ShaderSources<StandardShaderSource> sources;
+    sources.glsl4 = {
+        R"(
+            precision highp float;
+            layout(location = 0) in vec3 a_position;
+
+            void main() {
+                gl_Position = vec4(a_position, 1.0);
+            }
+        )",
+        R"(
+            precision highp float;
+
+            layout(location = 0) in vec4 vColor;
+
+            layout(location = 0) out vec4 o_color;
+
+            void main() {
+                o_color = vColor;
+            }
+        )",
+    };
+
+    sources.glsl3 = {
+        R"(
+            in vec3 a_position;
+
+            void main() {
+                gl_Position = vec4(a_position, 1.0);
+            }
+        )",
+        R"(
+            precision mediump float;
+
+            in vec4 vColor;
+            out vec4 o_color;
+            void main() {
+                o_color = vColor;
+            }
+        )",
+    };
+
+    ShaderSources<GeometryShaderSource> geomSources;
+    geomSources.glsl4 =
+        R"(
+            #extension GL_ARB_viewport_array : enable
+            layout (triangles, invocations = 2) in;
+            layout (triangle_strip, max_vertices = 3) out;
+
+            layout (binding = 0) uniform UBO {
+                mat4 modelview[2];
+                mat4 projection[2];
+            };
+
+            layout(location = 0) out vec4 vColor;
+
+            void main() {
+                for (int i = 0; i < gl_in.length(); i++) {
+                    vec4 pos = gl_in[i].gl_Position;
+                    vec4 worldPos = modelview[gl_InvocationID] * pos;
+
+                    gl_Position = projection[gl_InvocationID] * worldPos;
+
+                    vColor = vec4(float(gl_InvocationID), 1.0 - float(gl_InvocationID), 0.0, 1.0);
+
+                    gl_ViewportIndex = gl_InvocationID;
+
+                gl_PrimitiveID = gl_PrimitiveIDIn;
+                    EmitVertex();
+                }
+                EndPrimitive();
+            }
+        )";
+    geomSources.glsl3 =
+        R"(
+            #extension GL_OES_viewport_array : enable
+            layout (triangles, invocations = 2) in;
+            layout (triangle_strip, max_vertices = 3) out;
+
+            layout (std140) uniform UBO {
+                mat4 modelview[2];
+                mat4 projection[2];
+            };
+
+            out vec4 vColor;
+
+            void main() {
+                for (int i = 0; i < gl_in.length(); i++) {
+                    vec4 pos = gl_in[i].gl_Position;
+                    vec4 worldPos = modelview[gl_InvocationID] * pos;
+
+                    gl_Position = projection[gl_InvocationID] * worldPos;
+
+                    vColor = vec4(float(gl_InvocationID), 1.0 - float(gl_InvocationID), 0.0, 1.0);
+
+                    gl_ViewportIndex = gl_InvocationID;
+
+                gl_PrimitiveID = gl_PrimitiveIDIn;
+                    EmitVertex();
+                }
+                EndPrimitive();
+            }
+        )";
+
+    StandardShaderSource &source     = TestBaseI::getAppropriateShaderSource(sources);
+    GeometryShaderSource &geomSource = TestBaseI::getAppropriateShaderSource(geomSources);
+
+    gfx::ShaderStageList shaderStageList;
+
+    gfx::ShaderStage vertexShaderStage;
+    vertexShaderStage.stage  = gfx::ShaderStageFlagBit::VERTEX;
+    vertexShaderStage.source = source.vert;
+    shaderStageList.emplace_back(std::move(vertexShaderStage));
+
+    gfx::ShaderStage geometryShaderStage;
+    geometryShaderStage.stage  = gfx::ShaderStageFlagBit::GEOMETRY;
+    geometryShaderStage.source = geomSource;
+    shaderStageList.emplace_back(std::move(geometryShaderStage));
+
+    gfx::ShaderStage fragmentShaderStage;
+    fragmentShaderStage.stage  = gfx::ShaderStageFlagBit::FRAGMENT;
+    fragmentShaderStage.source = source.frag;
+    shaderStageList.emplace_back(std::move(fragmentShaderStage));
+
+    gfx::UniformBlockList uniformBlockList = {
+        {0, 0, "UBO", {{"modelview", gfx::Type::MAT4, 2}, {"projection", gfx::Type::MAT4, 2}}, 1},
+    };
+    gfx::AttributeList attributeList = {{"a_position", gfx::Format::RGB32F, false, 0, false, 0}};
+
+    gfx::ShaderInfo shaderInfo;
+    shaderInfo.name       = "Basic Triangle";
+    shaderInfo.stages     = std::move(shaderStageList);
+    shaderInfo.attributes = std::move(attributeList);
+    shaderInfo.blocks     = std::move(uniformBlockList);
+    _shader               = device->createShader(shaderInfo);
+}
+
+void MultiViewportTest::createVertexBuffer() {
+    auto        obj       = loadOBJ("bunny.obj");
+    const auto &positions = obj.GetAttrib().vertices;
+
+    _vertexBuffer = device->createBuffer({
+        gfx::BufferUsage::VERTEX,
+        gfx::MemoryUsage::DEVICE,
+        static_cast<uint>(positions.size() * sizeof(float)),
+        3 * sizeof(float),
+    });
+    _vertexBuffer->update(positions.data(), positions.size() * sizeof(float));
+
+    const auto &          indicesInfo = obj.GetShapes()[0].mesh.indices;
+    std::vector<uint16_t> indices;
+    indices.reserve(indicesInfo.size());
+    std::transform(indicesInfo.begin(), indicesInfo.end(), std::back_inserter(indices),
+                   [](auto &&info) { return static_cast<uint16_t>(info.vertex_index); });
+
+    _indexBuffer = device->createBuffer({
+        gfx::BufferUsage::INDEX,
+        gfx::MemoryUsage::DEVICE,
+        static_cast<uint>(indices.size() * sizeof(uint16_t)),
+        sizeof(uint16_t),
+    });
+    _indexBuffer->update(indices.data(), indices.size() * sizeof(uint16_t));
+
+    gfx::BufferInfo uniformBufferInfo = {
+        gfx::BufferUsage::UNIFORM,
+        gfx::MemoryUsage::DEVICE | gfx::MemoryUsage::HOST,
+        TestBaseI::getUBOSize(sizeof(UBOSetting)),
+    };
+    _uniformBuffer = device->createBuffer(uniformBufferInfo);
+}
+
+void MultiViewportTest::createInputAssembler() {
+    gfx::Attribute          position = {"a_position", gfx::Format::RGB32F, false, 0, false};
+    gfx::InputAssemblerInfo inputAssemblerInfo;
+    inputAssemblerInfo.attributes.emplace_back(std::move(position));
+    inputAssemblerInfo.vertexBuffers.emplace_back(_vertexBuffer);
+    inputAssemblerInfo.indexBuffer = _indexBuffer;
+    _inputAssembler                = device->createInputAssembler(inputAssemblerInfo);
+}
+
+void MultiViewportTest::createPipeline() {
+    gfx::DescriptorSetLayoutInfo dslInfo;
+    dslInfo.bindings.push_back({0, gfx::DescriptorType::UNIFORM_BUFFER, 1, gfx::ShaderStageFlagBit::GEOMETRY});
+    _descriptorSetLayout = device->createDescriptorSetLayout(dslInfo);
+
+    _pipelineLayout = device->createPipelineLayout({{_descriptorSetLayout}});
+
+    _descriptorSet = device->createDescriptorSet({_descriptorSetLayout});
+
+    _descriptorSet->bindBuffer(0, _uniformBuffer);
+    _descriptorSet->update();
+
+    gfx::PipelineStateInfo pipelineInfo;
+    pipelineInfo.primitive                = gfx::PrimitiveMode::TRIANGLE_LIST;
+    pipelineInfo.shader                   = _shader;
+    pipelineInfo.inputState               = {_inputAssembler->getAttributes()};
+    pipelineInfo.renderPass               = renderPass;
+    pipelineInfo.rasterizerState.cullMode = gfx::CullMode::NONE;
+    pipelineInfo.pipelineLayout           = _pipelineLayout;
+
+    _pipelineState = device->createPipelineState(pipelineInfo);
+
+    _generalBarriers.push_back(device->getGeneralBarrier({
+        gfx::AccessFlagBit::TRANSFER_WRITE,
+        gfx::AccessFlagBit::VERTEX_SHADER_READ_UNIFORM_BUFFER |
+            gfx::AccessFlagBit::FRAGMENT_SHADER_READ_UNIFORM_BUFFER |
+            gfx::AccessFlagBit::VERTEX_BUFFER |
+            gfx::AccessFlagBit::INDEX_BUFFER,
+    }));
+
+    _generalBarriers.push_back(device->getGeneralBarrier({
+        gfx::AccessFlagBit::TRANSFER_WRITE,
+        gfx::AccessFlagBit::VERTEX_SHADER_READ_UNIFORM_BUFFER |
+            gfx::AccessFlagBit::FRAGMENT_SHADER_READ_UNIFORM_BUFFER,
+    }));
+}
+
+const float     _eyeSeperation  = 0.5F;
+const float     _fov            = 90.0F;
+const float     _zNear          = 1.0F;
+const float     _zFar           = 256.0F;
+constexpr float CAMERA_DISTANCE = 4.0F;
+const Vec3      _foreHead       = Vec3(0, CAMERA_DISTANCE * 0.5, CAMERA_DISTANCE);
+
+void MultiViewportTest::updateUniform() {
+    auto *swapchain = swapchains[0];
+
+    auto width  = swapchain->getWidth();
+    auto height = swapchain->getHeight();
+
+    float aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+
+    // left eye
+    Mat4::createLookAt(_foreHead - Vec3(_eyeSeperation / 2.0, 0, 0), Vec3(0, 0, 0), Vec3(0, 1, 0), _setting.modelview);
+    TestBaseI::createPerspective(_fov, aspectRatio, _zNear, _zFar, _setting.projection, swapchain);
+    // right eye
+    Mat4::createLookAt(_foreHead + Vec3(_eyeSeperation / 2.0, 0, 0), Vec3(0, 0, 0), Vec3(0, 1, 0), &(_setting.modelview[1]));
+    TestBaseI::createPerspective(_fov, aspectRatio, _zNear, _zFar, &(_setting.projection[1]), swapchain);
+
+    static Mat4 model;
+    model.rotateY(0.01);
+
+    _setting.modelview[0].multiply(model);
+    _setting.modelview[1].multiply(model);
+
+    _uniformBuffer->update(&_setting, sizeof(_setting));
+}
+
+#define TEST_OCCLUSION_QUERY 0
+
+void MultiViewportTest::onTick() {
+    auto *swapchain = swapchains[0];
+    auto *fbo       = fbos[0];
+
+    uint generalBarrierIdx = _frameCount ? 1 : 0;
+
+    gfx::Color clearColor = {0, 0, 0, 1.0F};
+
+    device->acquire(&swapchain, 1);
+
+    updateUniform();
+
+    gfx::Rect renderArea = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
+
+    auto *commandBuffer = commandBuffers[0];
+    commandBuffer->begin();
+
+    if (TestBaseI::MANUAL_BARRIER) {
+        commandBuffer->pipelineBarrier(_generalBarriers[generalBarrierIdx]);
+    }
+
+    static gfx::Rect viewports[2] = {
+        {0, 0, swapchain->getWidth() / 2, swapchain->getHeight()},
+        {static_cast<int>(swapchain->getWidth() / 2), 0, swapchain->getWidth() / 2, swapchain->getHeight()},
+    };
+
+    commandBuffer->beginRenderPass(fbo->getRenderPass(), fbo, renderArea, &clearColor, 1.0F, 0);
+    commandBuffer->bindPipelineState(_pipelineState);
+    commandBuffer->setViewports(viewports, 2);
+    commandBuffer->bindInputAssembler(_inputAssembler);
+    commandBuffer->bindDescriptorSet(0, _descriptorSet);
+    commandBuffer->draw(_inputAssembler);
+    commandBuffer->endRenderPass();
+
+    commandBuffer->end();
+
+    device->flushCommands(commandBuffers);
+    device->getQueue()->submit(commandBuffers);
+    device->present();
+}
+
+} // namespace cc

--- a/tests/MultiViewportTest.h
+++ b/tests/MultiViewportTest.h
@@ -4,18 +4,19 @@
 
 namespace cc {
 
-class BasicTriangle : public TestBaseI {
+class MultiViewportTest : public TestBaseI {
 public:
-    DEFINE_CREATE_METHOD(BasicTriangle)
+    DEFINE_CREATE_METHOD(MultiViewportTest)
     using TestBaseI::TestBaseI;
 
     bool onInit() override;
     void onTick() override;
     void onDestroy() override;
+    void updateUniform();
 
-    struct Vertex {
-        float pos[2];
-        float col[3];
+    struct UBOSetting {
+        Mat4 modelview[2];
+        Mat4 projection[2];
     };
 
 private:
@@ -27,7 +28,6 @@ private:
     gfx::Shader *             _shader                 = nullptr;
     gfx::Buffer *             _vertexBuffer           = nullptr;
     gfx::Buffer *             _uniformBuffer          = nullptr;
-    gfx::Buffer *             _uniformBufferMVP       = nullptr;
     gfx::DescriptorSet *      _descriptorSet          = nullptr;
     gfx::DescriptorSetLayout *_descriptorSetLayout    = nullptr;
     gfx::PipelineLayout *     _pipelineLayout         = nullptr;
@@ -36,6 +36,8 @@ private:
     gfx::InputAssembler *     _inputAssembler         = nullptr;
     gfx::Buffer *             _indirectBuffer         = nullptr;
     gfx::Buffer *             _indexBuffer            = nullptr;
+
+    UBOSetting _setting;
 };
 
 } // namespace cc

--- a/tests/StressTest.cc
+++ b/tests/StressTest.cc
@@ -401,7 +401,7 @@ void StressTest::recordRenderPass(uint jobIdx) {
     auto *fbo       = fbos[0];
 
     gfx::Rect     scissor = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
-    gfx::Viewport vp      = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
+    gfx::Rect vp      = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
 
     uint passIdx        = jobIdx / _threadCount;
     uint threadIdx      = jobIdx % _threadCount;
@@ -420,7 +420,6 @@ void StressTest::recordRenderPass(uint jobIdx) {
     if (dcCount) {
         commandBuffer->bindInputAssembler(_inputAssembler);
         commandBuffer->bindPipelineState(_pipelineState);
-        commandBuffer->setScissor(scissor);
         commandBuffer->setViewport(vp);
 
         for (uint j = 0, t = perThreadCount * threadIdx; j < dcCount; ++j, ++t) {
@@ -441,7 +440,7 @@ void StressTest::recordRenderPass(uint threadIdx) {
     auto *fbo       = fbos[0];
 
     gfx::Rect           scissor       = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
-    gfx::Viewport       vp            = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
+    gfx::Rect       vp            = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
     gfx::CommandBuffer *commandBuffer = _parallelCBs[threadIdx];
 
     for (uint i = 0u; i < PASS_COUNT; ++i) {
@@ -480,7 +479,7 @@ void StressTest::recordRenderPass(uint passIndex) {
     auto *fbo       = fbos[0];
 
     gfx::Rect     scissor   = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
-    gfx::Viewport vp        = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
+    gfx::Rect vp        = {0, 0, swapchain->getWidth(), swapchain->getHeight()};
 
     gfx::CommandBuffer *commandBuffer = _parallelCBs[passIndex];
 

--- a/tests/TestBase.cpp
+++ b/tests/TestBase.cpp
@@ -17,6 +17,7 @@
 #include "tests/ComputeTest.h"
 #include "tests/DepthTest.h"
 #include "tests/FrameGraphTest.h"
+#include "tests/MultiViewportTest.h"
 #include "tests/ParticleTest.h"
 #include "tests/ScriptTest/ScriptTest.h"
 #include "tests/StencilTest.h"
@@ -54,6 +55,8 @@ vector<TestBaseI::createFunc> TestBaseI::tests = {
     StressTest::create,
     FrameGraphTest::create,
     ClearScreen::create,
+    // ES2 is not supported
+    MultiViewportTest::create,
     BasicTriangle::create,
     BlendTest::create,
     ParticleTest::create,
@@ -363,26 +366,26 @@ gfx::Rect TestBaseI::getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swa
 
     switch (swapchain->getSurfaceTransform()) {
         case gfx::SurfaceTransform::ROTATE_90:
-            viewport.x   = static_cast<int>((1.F - y - h) * deviceWidth);
-            viewport.y    = static_cast<int>(x * deviceHeight);
+            viewport.x      = static_cast<int>((1.F - y - h) * deviceWidth);
+            viewport.y      = static_cast<int>(x * deviceHeight);
             viewport.width  = static_cast<uint>(h * deviceWidth);
             viewport.height = static_cast<uint>(w * deviceHeight);
             break;
         case gfx::SurfaceTransform::ROTATE_180:
-            viewport.x   = static_cast<int>((1.F - x - w) * deviceWidth);
-            viewport.y    = static_cast<int>((1.F - y - h) * deviceHeight);
+            viewport.x      = static_cast<int>((1.F - x - w) * deviceWidth);
+            viewport.y      = static_cast<int>((1.F - y - h) * deviceHeight);
             viewport.width  = static_cast<uint>(w * deviceWidth);
             viewport.height = static_cast<uint>(h * deviceHeight);
             break;
         case gfx::SurfaceTransform::ROTATE_270:
-            viewport.x   = static_cast<int>(y * deviceWidth);
-            viewport.y    = static_cast<int>((1.F - x - w) * deviceHeight);
+            viewport.x      = static_cast<int>(y * deviceWidth);
+            viewport.y      = static_cast<int>((1.F - x - w) * deviceHeight);
             viewport.width  = static_cast<uint>(h * deviceWidth);
             viewport.height = static_cast<uint>(w * deviceHeight);
             break;
         case gfx::SurfaceTransform::IDENTITY:
-            viewport.x   = static_cast<int>(x * deviceWidth);
-            viewport.y    = static_cast<int>(y * deviceHeight);
+            viewport.x      = static_cast<int>(x * deviceWidth);
+            viewport.y      = static_cast<int>(y * deviceHeight);
             viewport.width  = static_cast<uint>(w * deviceWidth);
             viewport.height = static_cast<uint>(h * deviceHeight);
             break;

--- a/tests/TestBase.cpp
+++ b/tests/TestBase.cpp
@@ -350,39 +350,39 @@ gfx::Extent TestBaseI::getOrientedSurfaceSize(gfx::Swapchain *swapchain) {
     }
 }
 
-gfx::Viewport TestBaseI::getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swapchain *swapchain) {
+gfx::Rect TestBaseI::getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swapchain *swapchain) {
     float x = relativeArea.x;
     float y = device->getCapabilities().clipSpaceSignY < 0.0F ? 1.F - relativeArea.y - relativeArea.w : relativeArea.y;
     float w = relativeArea.z;
     float h = relativeArea.w;
 
-    gfx::Viewport viewport;
+    gfx::Rect viewport;
 
     auto deviceWidth  = static_cast<float>(swapchain->getWidth());
     auto deviceHeight = static_cast<float>(swapchain->getHeight());
 
     switch (swapchain->getSurfaceTransform()) {
         case gfx::SurfaceTransform::ROTATE_90:
-            viewport.left   = static_cast<int>((1.F - y - h) * deviceWidth);
-            viewport.top    = static_cast<int>(x * deviceHeight);
+            viewport.x   = static_cast<int>((1.F - y - h) * deviceWidth);
+            viewport.y    = static_cast<int>(x * deviceHeight);
             viewport.width  = static_cast<uint>(h * deviceWidth);
             viewport.height = static_cast<uint>(w * deviceHeight);
             break;
         case gfx::SurfaceTransform::ROTATE_180:
-            viewport.left   = static_cast<int>((1.F - x - w) * deviceWidth);
-            viewport.top    = static_cast<int>((1.F - y - h) * deviceHeight);
+            viewport.x   = static_cast<int>((1.F - x - w) * deviceWidth);
+            viewport.y    = static_cast<int>((1.F - y - h) * deviceHeight);
             viewport.width  = static_cast<uint>(w * deviceWidth);
             viewport.height = static_cast<uint>(h * deviceHeight);
             break;
         case gfx::SurfaceTransform::ROTATE_270:
-            viewport.left   = static_cast<int>(y * deviceWidth);
-            viewport.top    = static_cast<int>((1.F - x - w) * deviceHeight);
+            viewport.x   = static_cast<int>(y * deviceWidth);
+            viewport.y    = static_cast<int>((1.F - x - w) * deviceHeight);
             viewport.width  = static_cast<uint>(h * deviceWidth);
             viewport.height = static_cast<uint>(w * deviceHeight);
             break;
         case gfx::SurfaceTransform::IDENTITY:
-            viewport.left   = static_cast<int>(x * deviceWidth);
-            viewport.top    = static_cast<int>(y * deviceHeight);
+            viewport.x   = static_cast<int>(x * deviceWidth);
+            viewport.y    = static_cast<int>(y * deviceHeight);
             viewport.width  = static_cast<uint>(w * deviceWidth);
             viewport.height = static_cast<uint>(h * deviceHeight);
             break;

--- a/tests/TestBase.h
+++ b/tests/TestBase.h
@@ -150,7 +150,7 @@ public:
     static void               createOrthographic(float left, float right, float bottom, float top, float near, float zFar, Mat4 *dst, gfx::Swapchain *swapchain);
     static void               createPerspective(float fov, float aspect, float near, float zFar, Mat4 *dst, gfx::Swapchain *swapchain);
     static gfx::Extent        getOrientedSurfaceSize(gfx::Swapchain *swapchain);
-    static gfx::Viewport      getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swapchain *swapchain);
+    static gfx::Rect      getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swapchain *swapchain);
     static uint               getUBOSize(uint size);
     static uint               getMipmapLevelCounts(uint width, uint height);
     static uint               getAlignedUBOStride(uint stride);

--- a/tests/TestBase.h
+++ b/tests/TestBase.h
@@ -28,7 +28,8 @@ struct StandardShaderSource {
     String frag;
 };
 
-using ComputeShaderSource = String;
+using ComputeShaderSource  = String;
+using GeometryShaderSource = String;
 
 template <typename T>
 struct ShaderSources {
@@ -150,7 +151,7 @@ public:
     static void               createOrthographic(float left, float right, float bottom, float top, float near, float zFar, Mat4 *dst, gfx::Swapchain *swapchain);
     static void               createPerspective(float fov, float aspect, float near, float zFar, Mat4 *dst, gfx::Swapchain *swapchain);
     static gfx::Extent        getOrientedSurfaceSize(gfx::Swapchain *swapchain);
-    static gfx::Rect      getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swapchain *swapchain);
+    static gfx::Rect          getViewportBasedOnDevice(const Vec4 &relativeArea, gfx::Swapchain *swapchain);
     static uint               getUBOSize(uint size);
     static uint               getMipmapLevelCounts(uint width, uint height);
     static uint               getAlignedUBOStride(uint stride);

--- a/tests/utils/StandardPipelineUtils.cpp
+++ b/tests/utils/StandardPipelineUtils.cpp
@@ -780,7 +780,7 @@ void StandardDeferredPipeline::recordCommandBuffer(gfx::Device *device, gfx::Com
         data.depthStencil = builder.write(data.depthStencil, depthStencilAttachmentInfo);
         builder.writeToBlackboard(DEPTH_STENCIL_NAME, data.depthStencil);
 
-        gfx::Viewport vp{renderArea.x, renderArea.y, renderArea.width, renderArea.height, 0, 1};
+        gfx::Rect vp{renderArea.x, renderArea.y, renderArea.width, renderArea.height};
         gfx::Rect     rect{renderArea.x, renderArea.y, renderArea.width, renderArea.height};
         builder.setViewport(vp, rect);
     };
@@ -838,7 +838,7 @@ void StandardDeferredPipeline::recordCommandBuffer(gfx::Device *device, gfx::Com
         data.depthStencil = builder.write(data.depthStencil, depthStencilAttachmentInfo);
         builder.writeToBlackboard(DEPTH_STENCIL_NAME, data.depthStencil);
 
-        gfx::Viewport vp{renderArea.x, renderArea.y, renderArea.width, renderArea.height, 0, 1};
+        gfx::Rect vp{renderArea.x, renderArea.y, renderArea.width, renderArea.height};
         gfx::Rect     rect{renderArea.x, renderArea.y, renderArea.width, renderArea.height};
         builder.setViewport(vp, rect);
     };


### PR DESCRIPTION
Re: cocos-creator/3d-tasks#7895

1. Adapt the test cases to use GFX's multi-viewport feature.
2. Add a new test case `MultiViewportTest`.
![image](https://user-images.githubusercontent.com/24495793/158555058-8669dde3-1a65-4945-8b8e-799bbfcfdb20.png)
